### PR TITLE
Minor improvements

### DIFF
--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -20,6 +20,11 @@ fn main() -> Result<()> {
     let workspace = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let workspace = workspace.parent().unwrap().canonicalize()?;
 
+    let patch_only = match env::args().nth(2).as_deref() {
+        Some("--patch-only") => true,
+        _ => false,
+    };
+
     // Verify that a chip was specified and that it is valid, and if so perform all
     // steps necessary to generate the PAC for said chip.
     if let Some(chip) = env::args().nth(1) {
@@ -35,10 +40,12 @@ fn main() -> Result<()> {
                 fs::remove_dir_all(&path.join("src")).ok();
 
                 patch_svd(chip, &path)?;
-                generate_pac(chip, &path)?;
-                format(&path)?;
-                clean(&path)?;
-                build(&path)?;
+                if !patch_only {
+                    generate_pac(chip, &path)?;
+                    format(&path)?;
+                    clean(&path)?;
+                    build(&path)?;
+                }
             }
             _ => bail!("invalid chip '{}' specified", chip),
         }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -67,7 +67,7 @@ fn generate_pac(chip: &str, path: &PathBuf) -> Result<()> {
     let input = fs::read_to_string(svd_file)?;
 
     let mut config = Config::default();
-    config.target = Target::XtensaLX;
+    config.target = get_svd2rust_target(path)?;
     config.output_dir = path.clone();
 
     let device = load_from(&input, &config)?;
@@ -121,7 +121,7 @@ fn build(path: &PathBuf) -> Result<()> {
             &format!("+{channel}"),
             "build",
             "-Z",
-            "build-std",
+            "build-std=core",
             "--target",
             &target,
         ])
@@ -145,6 +145,14 @@ fn get_target(path: &PathBuf) -> Result<String> {
     let target = extract_toml_value(&config_file, &["build", "target"])?;
 
     Ok(target)
+}
+
+fn get_svd2rust_target(path: &PathBuf) -> Result<Target> {
+    if get_target(path)?.contains("riscv") {
+        Ok(Target::RISCV)
+    } else {
+        Ok(Target::XtensaLX)
+    }
 }
 
 fn extract_toml_value(path: &PathBuf, keys: &[&str]) -> Result<String> {


### PR DESCRIPTION
This contains basically two small things
- pass `build-std=core` and the right target to svd2rust
- a "quality of life" addition: a "--patch-only" option to omit all the steps after patching the SVD - that's because for me it usually takes some iterations to make a patch produce the desired output ... not really needed but can speed up things a bit

Maybe we should use CLAP for the parameters and also add a "--help" option. However, it's not really an end-user crate and I cannot think of much more options to add - so I'm not sure about that

But generally, this repo is a big step forward - I really like the absence of _make_ and _Python_ - not to mention the monorepo