### PR TITLE
Cleanup ESP32S2 IO_MUX

### DIFF
--- a/esp32s2/Cargo.toml
+++ b/esp32s2/Cargo.toml
@@ -27,15 +27,10 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 bare-metal = "1.0"
 vcell = "0.1"
-xtensa-lx = "0.4"
-
-[dependencies.xtensa-lx-rt]
-git = "https://github.com/esp-rs/xtensa-lx-rt.git"
-branch = "unify-xtensa-asm"
-features = ["lx6"]
-optional = true
+xtensa-lx = "0.6.0"
+xtensa-lx-rt = { version = "0.8.0", optional = true }
 
 [features]
 # NOTE: these features will need to be updated when support for LX7 is added.
-default = ["xtensa-lx/lx6"]
-rt = ["xtensa-lx-rt/lx6"]
+default = ["xtensa-lx/esp32"]
+rt = ["xtensa-lx-rt/esp32"]

--- a/esp32s2/svd/patches/esp32s2.yaml
+++ b/esp32s2/svd/patches/esp32s2.yaml
@@ -10,3 +10,24 @@ GPIO:
       "IN_DATA1_NEXT":
         access: read-write
         name: data_next
+IO_MUX:
+  _delete:
+    _registers:
+      - XTAL_32K_P
+      - XTAL_32K_N
+      - DAC_1
+      - DAC_2
+      - SPICS1
+      - SPIHD
+      - SPIWP
+      - SPICS0
+      - SPIDK
+      - SPIQ
+      - SPID
+      - MTCK
+      - MTDO
+      - MTDI
+      - MTMS
+      - U0TXD
+      - U0RXD
+      - SPICLK


### PR DESCRIPTION
This should fix
> For some reason ~2/3 of the registers in the IO_MUX for the ESP32-S2 are fields, and the rest are methods, but the XML for each register is identical other than name/description/addressOffset

Found out that some of the registers were duplicated/aliased e.g. _GPIO15_ and _XTAL_32K_P_ both used the same _addressOffset_ - since the register definition is always the same it's probably safe to just remove the duplicates

This also updates the dependencies of esp32s2 to make it build with esp-rustc 1.58